### PR TITLE
Pass plaintext objects through the per-bucket read path instead of buffering them

### DIFF
--- a/docs/design/per-bucket-encryption.md
+++ b/docs/design/per-bucket-encryption.md
@@ -114,8 +114,12 @@ object as one message:
   **key version**. Key version 0 in a `VS3S` blob means it was sealed with a
   server-wide key (per-bucket versions start at 1), so it routes to the legacy key.
 - If it starts with neither magic, it is either a legacy global-key object
-  (decrypt with the legacy engine key if configured) or plaintext (opt-out bucket)
-, handled by the integration layer.
+  (decrypt with the legacy engine key if configured) or plaintext (opt-out
+  bucket). The decision is made from the first four bytes; a plaintext object
+  is handed back as the underlying seekable reader and is never buffered, so a
+  range read costs only its range and object size is unbounded (#53). Only
+  `VS3X` and legacy global-key blobs are read whole, because those formats
+  cannot be authenticated any other way.
 
 ### Per-bucket opt-in / opt-out
 

--- a/internal/storage/bucketenc.go
+++ b/internal/storage/bucketenc.go
@@ -91,9 +91,37 @@ func (e *PerBucketEngine) open(bucket string, data []byte) ([]byte, error) {
 	return data, nil
 }
 
-func (e *PerBucketEngine) readAll(r ReadSeekCloser) ([]byte, error) {
+// maxWholeObjectStored bounds the blobs that still take the whole-object read
+// path (VS3X and legacy global-key objects): the plaintext limit plus room for
+// the largest header, nonce and tag any of those formats carries. Plaintext
+// objects never pass through here and have no such limit.
+const maxWholeObjectStored = maxEncryptedSize + 64
+
+// readWhole reads a whole-object blob into memory so it can be authenticated.
+// A blob larger than the format allows is refused outright: the previous
+// LimitReader silently cut such objects short and handed the client an
+// incomplete file with a 200 (issue #53).
+func (e *PerBucketEngine) readWhole(r ReadSeekCloser, stored int64) ([]byte, error) {
 	defer r.Close()
-	return io.ReadAll(io.LimitReader(r, maxEncryptedSize+int64(64)))
+	if stored < 0 || stored > maxWholeObjectStored {
+		return nil, fmt.Errorf("storage: encrypted object too large (%d bytes)", stored)
+	}
+	buf := make([]byte, stored)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// peekPerBucketHeader reports whether the blob starts with the VS3X whole-object
+// header, leaving the reader positioned at the start.
+func peekPerBucketHeader(r io.ReadSeeker) (bool, error) {
+	var magic [4]byte
+	n, _ := io.ReadFull(r, magic[:])
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return false, err
+	}
+	return bucketcrypto.HasHeader(magic[:n]), nil
 }
 
 // put writes reader through the bucket's key, streaming when the bucket is
@@ -143,7 +171,7 @@ func (e *PerBucketEngine) streamKey(bucket string, keyVersion uint32) ([]byte, e
 
 // get resolves the format from the stored blob: VS3S streams with the key
 // version named in its header, VS3X and legacy global-key blobs take the
-// whole-object path they were written with.
+// whole-object path they were written with, and plaintext passes through.
 func (e *PerBucketEngine) get(bucket string, reader ReadSeekCloser, stored int64) (ReadSeekCloser, int64, error) {
 	// An empty object carries no header and no ciphertext, so there is nothing to
 	// decrypt. Without this it fell through to the whole-object path, which
@@ -170,7 +198,23 @@ func (e *PerBucketEngine) get(bucket string, reader ReadSeekCloser, stored int64
 		return sr, sr.Size(), nil
 	}
 
-	data, err := e.readAll(reader)
+	// Only two formats remain: a VS3X whole-object blob, or a headerless blob
+	// that is legacy global-key ciphertext when a legacy key is configured and
+	// plaintext otherwise. Plaintext needs no work, so it is handed back as the
+	// underlying reader: seekable, streamed, and never held in memory. Before
+	// this, every object in an opted-out bucket was read whole on every GET,
+	// which turned a 1 KB range read of a large object into a full copy of it
+	// and truncated anything past 1 GiB (issue #53).
+	perBucket, err := peekPerBucketHeader(reader)
+	if err != nil {
+		reader.Close()
+		return nil, 0, fmt.Errorf("read object: %w", err)
+	}
+	if !(perBucket && e.manager() != nil) && e.legacy == nil {
+		return reader, stored, nil
+	}
+
+	data, err := e.readWhole(reader, stored)
 	if err != nil {
 		return nil, 0, fmt.Errorf("read object: %w", err)
 	}

--- a/internal/storage/bucketenc_test.go
+++ b/internal/storage/bucketenc_test.go
@@ -107,3 +107,66 @@ func TestPerBucketEngine_NoManagerIsPlaintext(t *testing.T) {
 		t.Fatal("without a manager, objects must be stored as plaintext")
 	}
 }
+
+// An opted-out bucket's objects are plaintext, so a GET must hand back the
+// underlying reader rather than a copy of the object: no buffering, and Seek
+// reaches the stored bytes directly (issue #53).
+func TestPerBucketEngine_OptOutReadPassesThrough(t *testing.T) {
+	fs, _ := NewFileSystem(t.TempDir())
+	mgr := newMgr(t)
+	pe, _ := NewPerBucketEngine(fs, nil)
+	pe.SetManager(mgr)
+	fs.CreateBucketDir("plain")
+
+	data := bytes.Repeat([]byte("0123456789"), 1000)
+	if _, _, err := pe.PutObject("plain", "k", bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatal(err)
+	}
+	r, size, err := pe.GetObject("plain", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	if size != int64(len(data)) {
+		t.Fatalf("size = %d, want %d", size, len(data))
+	}
+	if _, buffered := r.(*bytesReadSeekCloser); buffered {
+		t.Fatal("plaintext object was read into memory instead of passed through")
+	}
+	if _, err := r.Seek(5000, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	got := make([]byte, 10)
+	if _, err := io.ReadFull(r, got); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, data[5000:5010]) {
+		t.Fatalf("range read = %q, want %q", got, data[5000:5010])
+	}
+}
+
+// VS3X blobs (the pre-streaming per-bucket format) still decrypt through the
+// whole-object path.
+func TestPerBucketEngine_WholeObjectFormatStillReads(t *testing.T) {
+	fs, _ := NewFileSystem(t.TempDir())
+	mgr := newMgr(t)
+	pe, _ := NewPerBucketEngine(fs, nil)
+	pe.SetManager(mgr)
+	fs.CreateBucketDir("enc")
+	mgr.EnableBucket("enc")
+
+	plain := []byte("sealed as a single message before 4.4.53")
+	blob, encrypted, err := mgr.Encrypt("enc", plain)
+	if err != nil || !encrypted {
+		t.Fatalf("Encrypt: %v (encrypted=%v)", err, encrypted)
+	}
+	if !bucketcrypto.HasHeader(blob) {
+		t.Fatal("test expects a VS3X blob")
+	}
+	if _, _, err := fs.PutObject("enc", "old", bytes.NewReader(blob), int64(len(blob))); err != nil {
+		t.Fatal(err)
+	}
+	if got := getPlain(t, pe, "enc", "old"); !bytes.Equal(got, plain) {
+		t.Fatalf("VS3X round-trip mismatch: %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #53.

## What

With `encryption.enabled: true` and `encryption.per_bucket: true`, `PerBucketEngine.get`
read every object that was not a `VS3S` stream whole into memory before deciding what
format it was. Objects in buckets that never opted into encryption are plaintext and
need no processing, yet they took that path on every GET.

This change decides the format from the first four bytes instead:

- `VS3S` stream: unchanged, decrypted in 1 MiB chunks.
- `VS3X` whole-object blob, or a headerless blob with `legacy_key` configured: still read
  whole, since those formats cannot be authenticated any other way. An object past the
  1 GiB format limit is now refused with ailently truncated.
- Anything else is plaintext and is returnble reader. Nothing
  is buffered, a range request reads only  size limit.

## Why

A 1 KB range read of a 594 MiB plaintext object copied all 594 MiB, and twenty
concurrent ones cost roughly 12 GiB of tranty full reads
from disk. Because that load went through a `LimitReader` capped at 1 GiB, anything
larger was handed to the client truncated with a 200 and no error.

## Verification

Reproduced the issue end to end with both flags on, a bucket with encryption left off,
a 600 MiB object, and 20 concurrent 1 KB range GETs:

| | peak server RSS | responses |
|---|---|---|
| before | ~15.4 GiB | 20 × 206, 1024 bytes each |
| after | ~31 MB | 20 × 206, 1024 bytes east source |

A full GET of the same object after the change returns 200 with a matching md5.

Tests added in `bucketenc_test.go`:

- `OptOutReadPassesThrough`: a plaintext oderlying reader,
  not a `bytesReadSeekCloser`, and Seek plus range read return the right bytes. Fails
  on the previous code.
- `WholeObjectFormatStillReads`: a `VS3X` isk still decrypts,
  guarding the pre-4.4.53 format.

Existing tests cover the legacy global-keyt ./...` and
`npm run build` pass.
